### PR TITLE
ci: add OpenVSX publishing and refactor publish workflow

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,0 +1,130 @@
+name: Publish Test Pipeline
+
+on:
+  push:
+    tags:
+      - 'v*.*.*-test'
+
+jobs:
+  build:
+    name: Build Extension (Test)
+    runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.package_info.outputs.package_name }}
+      package_version: ${{ steps.package_info.outputs.package_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Setup Environment
+        id: package_info
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name + '-' + require('./package.json').version")
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+          echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+      - name: Verify Version
+        run: |
+          EXPECTED_TAG="refs/tags/v${{ env.PACKAGE_VERSION }}-test"
+          if [[ "$EXPECTED_TAG" != "${{ github.ref }}" ]]; then
+            echo "::error::Version Mismatch. expected=$EXPECTED_TAG actual=${{ github.ref }}"
+            exit 1
+          fi
+      - name: Install Dependencies
+        run: |
+          npm install pnpm -g
+          pnpm install --no-frozen-lockfile
+      - name: Package Extension
+        run: pnpm run package
+      - name: Upload Extension Package
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-package-test
+          path: ./${{ env.PACKAGE_NAME }}.vsix
+          if-no-files-found: error
+
+  publish_vscode_test:
+    name: VS Code Publish Dry-Run
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ needs.build.result == 'success' }}
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Download Extension Package
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-package-test
+          path: .
+      - name: Install VSCE
+        run: npm install -g @vscode/vsce
+      - name: VSCE Dry-Run
+        run: vsce publish --no-dependencies --packagePath ./${{ needs.build.outputs.package_name }}.vsix --pat ${{ secrets.TSWAGGER_PERSONAL_ACCESS_TOKEN }} --dryRun
+
+  publish_openvsx_test:
+    name: OpenVSX Publish Dry-Run
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ needs.build.result == 'success' }}
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Download Extension Package
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-package-test
+          path: .
+      - name: Install OVSX
+        run: npm install -g ovsx
+      - name: OpenVSX Dry-Run Marker
+        run: |
+          ovsx --version
+          echo "OpenVSX dry-run: skip real publish in test pipeline"
+
+  notify_preview:
+    name: Output DingTalk Markdown Preview
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - publish_vscode_test
+      - publish_openvsx_test
+    if: ${{ always() && needs.build.result == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Generate Changelog
+        id: changelog
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ needs.build.outputs.package_version }}
+          path: ./CHANGELOG.md
+      - name: Generate Dingtalk Text
+        id: dingtalk_text
+        env:
+          PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}
+          CHANGELOG_CHANGES: ${{ steps.changelog.outputs.changes }}
+          VSCODE_PUBLISH_STATUS: ${{ needs.publish_vscode_test.result }}
+          OPENVSX_PUBLISH_STATUS: ${{ needs.publish_openvsx_test.result }}
+        run: printf 'text=%s\n' "$(node ./scripts/generate-dingtalk-text.js)" >> "$GITHUB_OUTPUT"
+      - name: Write Markdown Preview To Job Summary
+        env:
+          MARKDOWN_TEXT: ${{ steps.dingtalk_text.outputs.text }}
+        run: |
+          {
+            echo "## TSwagger Test Notification Preview"
+            echo ""
+            echo "**Tag**: ${{ github.ref_name }}"
+            echo ""
+            echo "### Markdown"
+            echo ""
+            node -e "console.log(JSON.parse(process.env.MARKDOWN_TEXT || '\"\"'))"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -49,7 +49,7 @@ jobs:
           if-no-files-found: error
 
   publish_vscode_test:
-    name: VS Code Publish Dry-Run
+    name: VS Code Publish Validation
     runs-on: ubuntu-latest
     needs: build
     if: ${{ needs.build.result == 'success' }}
@@ -65,8 +65,10 @@ jobs:
           path: .
       - name: Install VSCE
         run: npm install -g @vscode/vsce
-      - name: VSCE Dry-Run
-        run: vsce publish --no-dependencies --packagePath ./${{ needs.build.outputs.package_name }}.vsix --pat ${{ secrets.TSWAGGER_PERSONAL_ACCESS_TOKEN }} --dryRun
+      - name: Verify VSIX Artifact Exists
+        run: test -f ./${{ needs.build.outputs.package_name }}.vsix
+      - name: Verify VS Code Marketplace PAT
+        run: vsce verify-pat OrcaTeam --pat ${{ secrets.TSWAGGER_PERSONAL_ACCESS_TOKEN }}
 
   publish_openvsx_test:
     name: OpenVSX Publish Dry-Run

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,5 +1,8 @@
 name: Publish Test Pipeline
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
     tags:

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
       - name: Download Extension Package
         uses: actions/download-artifact@v4
         with:
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
       - name: Download Extension Package
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,8 +1,5 @@
 name: Publish Test Pipeline
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 on:
   push:
     tags:
@@ -17,7 +14,7 @@ jobs:
       package_version: ${{ steps.package_info.outputs.package_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -45,7 +42,7 @@ jobs:
       - name: Package Extension
         run: pnpm run package
       - name: Upload Extension Package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: extension-package-test
           path: ./${{ env.PACKAGE_NAME }}.vsix
@@ -62,7 +59,7 @@ jobs:
         with:
           node-version: '24'
       - name: Download Extension Package
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: extension-package-test
           path: .
@@ -84,7 +81,7 @@ jobs:
         with:
           node-version: '24'
       - name: Download Extension Package
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: extension-package-test
           path: .
@@ -105,7 +102,7 @@ jobs:
     if: ${{ always() && needs.build.result == 'success' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Generate Changelog
         id: changelog
         uses: mindsers/changelog-reader-action@v2

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -14,9 +14,9 @@ jobs:
       package_version: ${{ steps.package_info.outputs.package_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
       - name: Setup Environment
@@ -42,7 +42,7 @@ jobs:
       - name: Package Extension
         run: pnpm run package
       - name: Upload Extension Package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: extension-package-test
           path: ./${{ env.PACKAGE_NAME }}.vsix
@@ -55,11 +55,11 @@ jobs:
     if: ${{ needs.build.result == 'success' }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Download Extension Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: extension-package-test
           path: .
@@ -77,11 +77,11 @@ jobs:
     if: ${{ needs.build.result == 'success' }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Download Extension Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: extension-package-test
           path: .
@@ -102,7 +102,7 @@ jobs:
     if: ${{ always() && needs.build.result == 'success' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Generate Changelog
         id: changelog
         uses: mindsers/changelog-reader-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,14 +4,17 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - 'v*.*.*-*'
 
 jobs:
   build:
     name: Build Extension
     runs-on: ubuntu-latest
+    if: ${{ !endsWith(github.ref_name, '-test') }}
     outputs:
       package_name: ${{ steps.package_info.outputs.package_name }}
       package_version: ${{ steps.package_info.outputs.package_version }}
+      is_prerelease: ${{ steps.package_info.outputs.is_prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,12 +27,31 @@ jobs:
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           PACKAGE_NAME=$(node -p "require('./package.json').name + '-' + require('./package.json').version")
+          TAG_NAME="${{ github.ref_name }}"
+          IS_PRERELEASE="false"
+          if [[ "$TAG_NAME" == *-* ]] && [[ "$TAG_NAME" != *-test ]]; then
+            IS_PRERELEASE="true"
+          fi
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
           echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
           echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
       - name: Verify Version
-        run: node -e "if ('refs/tags/v' + '${{ env.PACKAGE_VERSION }}' !== '${{ github.ref }}') { console.log('::error' + 'Version Mismatch. refs/tags/v' + '${{ env.PACKAGE_VERSION }}', '${{ github.ref }}'); throw Error('Version Mismatch')} "
+        run: |
+          if [[ "${{ steps.package_info.outputs.is_prerelease }}" == "true" ]]; then
+            EXPECTED_PREFIX="refs/tags/v${{ env.PACKAGE_VERSION }}-"
+            if [[ "${{ github.ref }}" != "$EXPECTED_PREFIX"* ]]; then
+              echo "::error::Version Mismatch. expected_prefix=$EXPECTED_PREFIX actual=${{ github.ref }}"
+              exit 1
+            fi
+          else
+            EXPECTED_TAG="refs/tags/v${{ env.PACKAGE_VERSION }}"
+            if [[ "$EXPECTED_TAG" != "${{ github.ref }}" ]]; then
+              echo "::error::Version Mismatch. expected=$EXPECTED_TAG actual=${{ github.ref }}"
+              exit 1
+            fi
+          fi
       - name: Install Dependencies
         run: |
           npm install pnpm -g
@@ -47,6 +69,7 @@ jobs:
     name: Publish To VS Code Marketplace
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ needs.build.result == 'success' }}
     steps:
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -66,6 +89,7 @@ jobs:
     name: Publish To OpenVSX
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ needs.build.result == 'success' }}
     steps:
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -88,7 +112,7 @@ jobs:
       - build
       - publish_vscode
       - publish_openvsx
-    if: ${{ always() && (needs.publish_vscode.result == 'success' || needs.publish_openvsx.result == 'success') }}
+    if: ${{ always() && needs.build.result == 'success' && (needs.publish_vscode.result == 'success' || needs.publish_openvsx.result == 'success') }}
     permissions:
       contents: write
     steps:
@@ -115,10 +139,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref }}
-          name: v${{ needs.build.outputs.package_version }}
+          name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.changes }}
           draft: false
-          prerelease: false
+          prerelease: ${{ needs.build.outputs.is_prerelease }}
           files: ./${{ needs.build.outputs.package_name }}.vsix
       - name: Generate Dingtalk Text
         id: dingtalk_text

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,5 @@
 name: Publish Extension
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 on:
   push:
     tags:
@@ -20,7 +17,7 @@ jobs:
       is_prerelease: ${{ steps.package_info.outputs.is_prerelease }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -62,7 +59,7 @@ jobs:
       - name: Package Extension
         run: pnpm run package
       - name: Upload Extension Package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: extension-package
           path: ./${{ env.PACKAGE_NAME }}.vsix
@@ -79,7 +76,7 @@ jobs:
         with:
           node-version: '24'
       - name: Download Extension Package
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: extension-package
           path: .
@@ -99,7 +96,7 @@ jobs:
         with:
           node-version: '24'
       - name: Download Extension Package
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: extension-package
           path: .
@@ -120,13 +117,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: '18'
       - name: Download Extension Package
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: extension-package
           path: .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,9 +17,9 @@ jobs:
       is_prerelease: ${{ steps.package_info.outputs.is_prerelease }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
       - name: Setup Environment
@@ -59,7 +59,7 @@ jobs:
       - name: Package Extension
         run: pnpm run package
       - name: Upload Extension Package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: extension-package
           path: ./${{ env.PACKAGE_NAME }}.vsix
@@ -72,11 +72,11 @@ jobs:
     if: ${{ needs.build.result == 'success' }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Download Extension Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: extension-package
           path: .
@@ -92,11 +92,11 @@ jobs:
     if: ${{ needs.build.result == 'success' }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Download Extension Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: extension-package
           path: .
@@ -117,13 +117,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
       - name: Download Extension Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: extension-package
           path: .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
       - name: Download Extension Package
         uses: actions/download-artifact@v4
         with:
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
       - name: Download Extension Package
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,89 @@ on:
       - 'v*.*.*'
 
 jobs:
-  publish:
-    name: Publish Extension
+  build:
+    name: Build Extension
     runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.package_info.outputs.package_name }}
+      package_version: ${{ steps.package_info.outputs.package_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Setup Environment
+        id: package_info
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name + '-' + require('./package.json').version")
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+          echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+      - name: Verify Version
+        run: node -e "if ('refs/tags/v' + '${{ env.PACKAGE_VERSION }}' !== '${{ github.ref }}') { console.log('::error' + 'Version Mismatch. refs/tags/v' + '${{ env.PACKAGE_VERSION }}', '${{ github.ref }}'); throw Error('Version Mismatch')} "
+      - name: Install Dependencies
+        run: |
+          npm install pnpm -g
+          pnpm install --no-frozen-lockfile
+      - name: Package Extension
+        run: pnpm run package
+      - name: Upload Extension Package
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-package
+          path: ./${{ env.PACKAGE_NAME }}.vsix
+          if-no-files-found: error
+
+  publish_vscode:
+    name: Publish To VS Code Marketplace
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Download Extension Package
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-package
+          path: .
+      - name: Install VSCE
+        run: npm install -g @vscode/vsce
+      - name: Publish Extension
+        run: vsce publish --no-dependencies --packagePath ./${{ needs.build.outputs.package_name }}.vsix --pat ${{ secrets.TSWAGGER_PERSONAL_ACCESS_TOKEN }}
+
+  publish_openvsx:
+    name: Publish To OpenVSX
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Download Extension Package
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-package
+          path: .
+      - name: Install OVSX
+        run: npm install -g ovsx
+      - name: Publish Extension
+        run: ovsx publish ./${{ needs.build.outputs.package_name }}.vsix -p ${{ secrets.OPENVSX_PAT }}
+
+  release_and_notify:
+    name: Create Release And Notify
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - publish_vscode
+      - publish_openvsx
+    if: ${{ always() && (needs.publish_vscode.result == 'success' || needs.publish_openvsx.result == 'success') }}
     permissions:
       contents: write
     steps:
@@ -18,23 +98,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - name: Setup Environment
-        run: node -e "console.log('PACKAGE_VERSION=' + require('./package.json').version + '\nPACKAGE_NAME=' + require('./package.json').name + '-' + require('./package.json').version)" >> $GITHUB_ENV # set PACKAGE_VERSION and PACKAGE_NAME
-      - name: Verify Version
-        run: node -e "if ('refs/tags/v' + '${{ env.PACKAGE_VERSION }}' !== '${{ github.ref }}') { console.log('::error' + 'Version Mismatch. refs/tags/v' + '${{ env.PACKAGE_VERSION }}', '${{ github.ref }}'); throw Error('Version Mismatch')} "
-      - name: Install Dependencies
-        run: |
-          npm install pnpm -g
-          pnpm install --no-frozen-lockfile
-      - name: Package Extension
-        run: pnpm run package
-      - name: Publish Extension
-        run: pnpm run publish --packagePath ./${{ env.PACKAGE_NAME }}.vsix --pat ${{ secrets.TSWAGGER_PERSONAL_ACCESS_TOKEN }}
+      - name: Download Extension Package
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-package
+          path: .
       - name: Generate Changelog
         id: changelog
         uses: mindsers/changelog-reader-action@v2
         with:
-          version: ${{ env.PACKAGE_VERSION }}
+          version: ${{ needs.build.outputs.package_version }}
           path: ./CHANGELOG.md
       - name: Create GitHub Release
         id: create_release
@@ -42,16 +115,18 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref }}
-          name: v${{ env.PACKAGE_VERSION }}
+          name: v${{ needs.build.outputs.package_version }}
           body: ${{ steps.changelog.outputs.changes }}
           draft: false
           prerelease: false
-          files: ./${{ env.PACKAGE_NAME }}.vsix
+          files: ./${{ needs.build.outputs.package_name }}.vsix
       - name: Generate Dingtalk Text
         id: dingtalk_text
         env:
-          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+          PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}
           CHANGELOG_CHANGES: ${{ steps.changelog.outputs.changes }}
+          VSCODE_PUBLISH_STATUS: ${{ needs.publish_vscode.result }}
+          OPENVSX_PUBLISH_STATUS: ${{ needs.publish_openvsx.result }}
         run: printf 'text=%s\n' "$(node ./scripts/generate-dingtalk-text.js)" >> "$GITHUB_OUTPUT"
       - name: Dingtalk Notify
         uses: Orchardxyz/dingtalk-bot-message@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish Extension
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
     tags:

--- a/.github/workflows/test-dingtalk-text.yml
+++ b/.github/workflows/test-dingtalk-text.yml
@@ -1,8 +1,5 @@
 name: Test Dingtalk Text
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 on:
   push:
     branches:
@@ -21,7 +18,7 @@ jobs:
       PACKAGE_VERSION: 9.9.9-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-dingtalk-text.yml
+++ b/.github/workflows/test-dingtalk-text.yml
@@ -1,5 +1,8 @@
 name: Test Dingtalk Text
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   push:
     branches:
@@ -18,9 +21,9 @@ jobs:
       PACKAGE_VERSION: 9.9.9-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
       - name: Load Test Fixture

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "tswagger",
   "icon": "assets/images/logo.png",
   "description": "Generate typescript for swagger.",
-  "version": "2.4.0",
+  "version": "2.4.0-test",
   "private": "true",
   "author": "Orchard",
   "publisher": "OrcaTeam",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "tswagger",
   "icon": "assets/images/logo.png",
   "description": "Generate typescript for swagger.",
-  "version": "2.4.0-test",
+  "version": "2.4.0",
   "private": "true",
   "author": "Orchard",
   "publisher": "OrcaTeam",

--- a/scripts/generate-dingtalk-text.js
+++ b/scripts/generate-dingtalk-text.js
@@ -1,11 +1,47 @@
 const packageVersion = process.env.PACKAGE_VERSION || '';
 const changes = process.env.CHANGELOG_CHANGES || '';
+const vscodePublishStatus = process.env.VSCODE_PUBLISH_STATUS || 'success';
+const openvsxPublishStatus = process.env.OPENVSX_PUBLISH_STATUS || 'unknown';
 
-const text = `### TSwagger v${packageVersion} Published
+const marketplaceStatuses = [
+	{
+		label: 'VS Code Marketplace',
+		url: 'https://marketplace.visualstudio.com/items?itemName=OrcaTeam.tswagger',
+		status: vscodePublishStatus,
+	},
+	{
+		label: 'OpenVSX',
+		url: 'https://open-vsx.org/extension/OrcaTeam/tswagger',
+		status: openvsxPublishStatus,
+	},
+];
 
-**tswagger@${packageVersion}** has been published to the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=OrcaTeam.tswagger).
+const publishedMarketplaces = marketplaceStatuses.filter(
+	({ status }) => status === 'success',
+);
+const unpublishedMarketplaces = marketplaceStatuses.filter(
+	({ status }) => status !== 'success' && status !== 'unknown',
+);
 
-> **Note**: It might take a few minutes to appear on the marketplace.
+const publishedText = publishedMarketplaces.length
+	? `**Published in this run:**\n\n${publishedMarketplaces
+			.map(({ label, url }) => `- [${label}](${url})`)
+			.join('\n')}`
+	: '';
+
+const unpublishedText = unpublishedMarketplaces.length
+	? `**Not published in this run:**\n\n${unpublishedMarketplaces
+			.map(({ label }) => `- ${label}`)
+			.join('\n')}`
+	: '';
+
+const text = `### TSwagger v${packageVersion} Release Completed
+
+**tswagger@${packageVersion}** release workflow completed.
+
+${[publishedText, unpublishedText].filter(Boolean).join('\n\n')}
+
+> **Note**: It might take a few minutes to appear on the marketplaces.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR refactors the CI/CD publish pipeline to support publishing to **OpenVSX** in addition to the VS Code Marketplace, and introduces a dedicated test pipeline for validating credentials and workflow logic before a real release.

## Changes

- **New** publish-test.yml: Test pipeline for v*.*.*-test tags — validates VS Code PAT, runs OpenVSX dry-run, and previews DingTalk notification in Job Summary
- **Refactored** publish.yml: Split into parallel jobs (build → publish_vscode + publish_openvsx → release_and_notify); adds OpenVSX publish via ovsx; supports pre-release tags
- generate-dingtalk-text.js: Notification now reports publish status for both VS Code Marketplace and OpenVSX
- **Action upgrades**: checkout / setup-node → v6, upload-artifact → v7, download-artifact → v8; publish jobs use Node 24