### PR TITLE
chore(ci): fix extension release pipeline

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -9,6 +9,11 @@ on:
       - '.changeset/**'
       - 'pnpm-lock.yaml'
   workflow_dispatch:
+    inputs:
+      publish_existing_release:
+        description: 'Build and publish the current package.json version even if Release Please did not create a new release'
+        type: boolean
+        default: false
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -39,7 +44,7 @@ jobs:
     name: Build Extension
     runs-on: ubuntu-latest
     needs: release_pr
-    if: ${{ needs.release_pr.outputs.release_created == 'true' }}
+    if: ${{ needs.release_pr.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs.publish_existing_release) }}
     outputs:
       package_name: ${{ steps.package_info.outputs.package_name }}
       package_version: ${{ steps.package_info.outputs.package_version }}
@@ -162,7 +167,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ needs.build.outputs.release_tag }}
-          name: TSwagger Extension ${{ needs.build.outputs.release_tag }}
+          name: TSwagger Extension v${{ needs.build.outputs.package_version }}
           body: ${{ steps.changelog.outputs.changes }}
           draft: false
           prerelease: ${{ needs.build.outputs.is_prerelease }}

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "webview-watch": "node scripts/webview-dev.js",
     "esbuild-build": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "esbuild-watch": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch --define:process.env.NODE_ENV=\\\"development\\\"",
-    "package": "npm run webview-build && npm run esbuild-build -- --minify && node ./scripts/package-extension.js",
+    "package": "pnpm --filter @tswagger/types run build && pnpm --filter @tswagger/core run build && npm run webview-build && npm run esbuild-build -- --minify && node ./scripts/package-extension.js",
     "publish": "vsce publish --no-dependencies",
     "release:tag:extension:test": "node ./scripts/release/create-tag.js extension --suffix test --create",
     "release:npm:status": "changeset status --since=origin/master --verbose",


### PR DESCRIPTION
## Summary

- build `@tswagger/types` and `@tswagger/core` before packaging the VS Code extension
- allow manual `Release Extension` dispatch to publish the current package version when a Release Please release already exists
- format the GitHub Release title as `TSwagger Extension vX.Y.Z`

## Why

The 2.6.0 release run failed in `Build Extension > Package Extension` because esbuild could not resolve `@tswagger/core`. The workspace package entry points target `dist`, but the extension package script did not build workspace dependencies first.

## Verification

- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-extension.yml'); puts 'release-extension.yml ok'"`
- `node ./scripts/release/validate-release-boundaries.js`
- `pnpm run package`

## Follow-up after merge

Run `Release Extension` manually with `publish_existing_release=true` to rebuild and publish `extension-v2.6.0`.