### PR TITLE
feat(skills): add tswagger agent skills

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Using TSwagger",
+      "description": "Skills for generating and troubleshooting TypeScript artifacts with TSwagger.",
+      "skills": [
+        "tswagger-cli",
+        "tswagger-extension",
+        "tswagger-output"
+      ]
+    },
+    {
+      "title": "Building With TSwagger",
+      "description": "Skills for integrating TSwagger into custom tools and agent workflows.",
+      "skills": [
+        "tswagger-core"
+      ]
+    },
+    {
+      "title": "Contributing",
+      "description": "Skills for working on the TSwagger repository itself.",
+      "skills": [
+        "tswagger-contributing"
+      ]
+    }
+  ]
+}

--- a/skills/tswagger-cli/SKILL.md
+++ b/skills/tswagger-cli/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: tswagger-cli
+description: Use this skill when a developer wants to generate TypeScript types or service request files from Swagger/OpenAPI v2 with the @tswagger/cli package, automate generation in local scripts or CI, filter generation by tag/path/method, manage translation caching, or troubleshoot CLI arguments and output layout.
+---
+
+# TSwagger CLI
+
+Use this skill for scriptable TSwagger generation. Prefer the VS Code extension when the developer wants a visual workflow, selective point-and-click generation, or project-level UI configuration. Prefer `@tswagger/core` only when the developer is building their own integration.
+
+## First checks
+
+1. Confirm the input document is Swagger/OpenAPI v2. The CLI currently rejects non-v2 documents.
+2. Confirm whether the developer wants only types, only service files, or both.
+3. Ask for or infer the output directory before suggesting commands.
+4. If generated names are Chinese or unstable, check whether translation should stay enabled and whether a persistent cache directory is configured.
+
+## Common commands
+
+Generate types only:
+
+```sh
+tswagger --input ./swagger.json --output ./src/.tswagger --mode types
+```
+
+Generate service request files and the default fetch helper:
+
+```sh
+tswagger --input ./swagger.json --output ./src/.tswagger --mode services
+```
+
+Generate both types and services:
+
+```sh
+tswagger --input ./swagger.json --output ./src/.tswagger --mode all
+```
+
+Filter operations:
+
+```sh
+tswagger --input ./swagger.json --output ./src/.tswagger --tag User --method get
+tswagger --input ./swagger.json --output ./src/.tswagger --path /users
+```
+
+Disable translation or make translation caching stable:
+
+```sh
+tswagger --input ./swagger.json --output ./src/.tswagger --no-translate
+tswagger --input ./swagger.json --output ./src/.tswagger --cache-dir ./.tswagger-cache
+```
+
+## CLI options
+
+- `--input`: Required. Local path or HTTP(S) URL for the Swagger/OpenAPI v2 document.
+- `--output`: Required. Directory where generated artifacts are written.
+- `--mode`: `types`, `services`, or `all`. Defaults to `types`.
+- `--tag`: Include only matching tag names. Accepts comma-separated values.
+- `--path`: Include operations whose path contains the provided value. Accepts comma-separated values.
+- `--method`: Include matching HTTP methods. Accepts comma-separated values.
+- `--no-translate`: Disable translation-based naming.
+- `--cache-dir`: Persist translation cache in a chosen directory.
+
+## Output expectations
+
+- `types` mode writes files under `types/<tag>/<serviceName>.ts`.
+- `services` mode writes files under `services/<tag>/<serviceName>.ts` and creates `services/fetch.ts`.
+- `all` mode writes both trees.
+- The CLI groups operations by Swagger tags. Operations without tags are grouped under `default`.
+
+## Troubleshooting
+
+- If no files are generated, check whether `--tag`, `--path`, or `--method` filters excluded every operation.
+- If the CLI reports unsupported input, inspect whether the document is OpenAPI v3 instead of Swagger/OpenAPI v2.
+- If service names change between runs, use stable `operationId` values in the Swagger document and keep translation cache persistent.
+- If service imports do not match a project-specific request layer, adjust generated files after generation or use the VS Code extension configuration workflow for `fetchFilePath`.

--- a/skills/tswagger-contributing/SKILL.md
+++ b/skills/tswagger-contributing/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: tswagger-contributing
+description: Use this skill when contributing code to the orca-team/vscode-tswagger repository, changing the VS Code extension, @tswagger/cli, @tswagger/core, @tswagger/types, @tswagger/mcp, the webview, tests, changesets, release workflows, or repository documentation.
+---
+
+# Contributing to TSwagger
+
+Use this skill only when the user is modifying the `orca-team/vscode-tswagger` repository itself. For application-level usage questions, use one of the other TSwagger skills.
+
+## Repository map
+
+- Root package `tswagger`: VS Code extension. Entry: `src/extension.ts`. Generation controller: `src/controllers/generate/v2.ts`.
+- `@tswagger/core`: Shared generation primitives in `packages/core/src`.
+- `@tswagger/cli`: Scriptable generation package in `packages/cli/src`.
+- `@tswagger/types`: Shared public TypeScript contracts in `packages/types/src`.
+- `@tswagger/mcp`: MCP server for agent inspection and generation in `packages/mcp/src`.
+- `tswagger-webview`: Private extension webview workspace in `webview/src`.
+
+## Implementation guidance
+
+- Put shared Swagger parsing, naming, schema, and service-generation behavior in `@tswagger/core`.
+- Keep CLI argument parsing, document loading, output layout, and translation cache behavior in `@tswagger/cli`.
+- Keep VS Code commands, workspace config, webview messaging, and file-writing behavior in the root extension package.
+- Keep agent tool schemas and MCP-specific orchestration in `@tswagger/mcp`.
+- Update `@tswagger/types` when a public cross-package contract changes.
+- Add focused regression tests near the package whose behavior changed.
+
+## Validation commands
+
+Choose the smallest meaningful set:
+
+```sh
+pnpm --filter @tswagger/core run test-compile
+pnpm --filter @tswagger/core run test
+pnpm --filter @tswagger/cli run test
+pnpm --filter @tswagger/cli run build
+pnpm --filter @tswagger/types run build
+pnpm --filter @tswagger/mcp run test
+pnpm --filter @tswagger/mcp run build
+pnpm run webview-build
+pnpm run test-compile
+pnpm run lint
+```
+
+Use `pnpm run package` only when extension packaging confidence is needed.
+
+## Release and changeset rules
+
+- Extension releases use Release Please. Root `package.json` and root `CHANGELOG.md` belong to the extension release line.
+- Public npm package changes use Changesets.
+- Add a `.changeset/*.md` file for behavior or API changes in `packages/cli`, `packages/core`, `packages/types`, or `packages/mcp`.
+- Do not manually edit package-level versions or package `CHANGELOG.md` files on normal feature branches.
+- The npm version PR title is `chore: version npm packages`.
+- Extension release PRs must not include package-level release artifacts.
+
+## Repository rules
+
+- Do not create or suggest a branch name that starts with `codex`.
+- Use the `gh` command when reading GitHub workflows, CI status, or other GitHub-hosted status.
+- Avoid reverting unrelated user changes in a dirty worktree.
+- Keep generated build output out of commits unless the repository already tracks it for the touched package.

--- a/skills/tswagger-core/SKILL.md
+++ b/skills/tswagger-core/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: tswagger-core
+description: Use this skill when a developer wants to integrate @tswagger/core into custom tooling, build a generator around Swagger/OpenAPI v2 documents, call handleSwaggerPathV2/generateTypescriptFromAPIV2/generateServiceFromAPIV2, configure translation, or decide between @tswagger/core, @tswagger/cli, MCP, and the VS Code extension.
+---
+
+# TSwagger Core
+
+Use this skill for custom integrations built on `@tswagger/core`. Prefer the CLI for ordinary scriptable generation and the VS Code extension for visual project workflows.
+
+## When to use core
+
+Use `@tswagger/core` when the developer needs to:
+
+- embed TSwagger generation into another tool
+- control the input Swagger document and operation collection directly
+- preview generated artifacts without using the VS Code extension
+- build an agent or service around TSwagger primitives
+
+Do not use core for VS Code workspace behavior, UI state, or filesystem conventions that belong to the extension.
+
+## Main primitives
+
+- `configure({ translate })`: Provides the translation function used by name filtering.
+- `handleSwaggerPathV2(config)`: Groups operations and builds request/response/service metadata.
+- `generateTypescriptFromAPIV2(schema, document, mapping?, options?)`: Converts a Swagger v2 schema into TypeScript definitions.
+- `generateServiceImport(collection, sourcePath)`: Creates imports for used request helpers and `FetchResult`.
+- `generateServiceFromAPIV2(serviceInfo, config?)`: Creates a service request function for a single operation.
+
+## Integration flow
+
+1. Parse or receive a Swagger/OpenAPI v2 document.
+2. Build a collection of operations grouped by tag.
+3. Call `configure` if translation is required.
+4. Call `handleSwaggerPathV2` with request params, response body, and service options.
+5. For each service schema, call `generateTypescriptFromAPIV2`.
+6. If service functions are needed, call `generateServiceImport` and `generateServiceFromAPIV2`.
+7. Write or return artifacts in the host tool's preferred layout.
+
+## Important boundaries
+
+- Core expects OpenAPI v2 shapes from `openapi-types`.
+- Core does not parse remote documents by itself; parsing belongs in the host integration or CLI.
+- Core does not manage VS Code settings, project `config.json`, webviews, or `service.map.yaml` files.
+- Keep translation deterministic in automation by supplying a stable translate function or cache at the host layer.
+
+## When MCP is a better fit
+
+If an AI agent needs to inspect a Swagger document, list/search operations, preview generated artifacts, or generate files through a tool interface, suggest `@tswagger/mcp` instead of building a custom core wrapper from scratch.

--- a/skills/tswagger-extension/SKILL.md
+++ b/skills/tswagger-extension/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: tswagger-extension
+description: Use this skill when a developer wants to use or configure the tswagger VS Code extension, manage Swagger document URLs, generate TypeScript artifacts visually, configure config.json, set fetchFilePath/basePathMapping/swaggerUrls, or understand extension-generated files in an application project.
+---
+
+# TSwagger VS Code Extension
+
+Use this skill for developers using the `tswagger` VS Code extension inside an application project. The extension is best when users want to browse Swagger operations visually, choose specific APIs, rename generated symbols, and save results into the current workspace.
+
+## Recommended workflow
+
+1. Open the extension from the command palette with `<TSwagger> Generate Typescript` or from the editor context menu.
+2. Choose or manage Swagger document URLs in the extension UI.
+3. Select the API operations to generate.
+4. Review and rename generated type or service names when needed.
+5. Save generated files into the project.
+
+## Project config
+
+The extension uses a project-level `config.json` that is created automatically on first generation when needed.
+
+Important fields:
+
+- `fetchFilePath`: Import path for the project's request helper. It should start with `@`, where `@` represents the project `src` directory. Default: `@/utils/fetch`.
+- `addBasePathPrefix`: Whether generated service paths include the Swagger document `basePath`. Default: `true`.
+- `basePathMapping`: Optional mapping for replacing Swagger base paths, such as mapping `/api-v1` to `/api`.
+- `swaggerUrls`: Project-level Swagger document URL shortcuts for quick selection and synchronization.
+
+Example:
+
+```json
+{
+  "fetchFilePath": "@/utils/fetch",
+  "addBasePathPrefix": true,
+  "basePathMapping": {
+    "/api-v1": "/api"
+  },
+  "swaggerUrls": [
+    {
+      "url": "https://api-dev.example.com/v2/api-docs",
+      "remark": "dev"
+    }
+  ]
+}
+```
+
+## Fetch helper contract
+
+Generated service files expect the configured fetch module to export:
+
+- request methods: `get`, `post`, `put`, and `del`
+- a generic result type: `FetchResult`
+
+The `post` helper should support `FormData` when the Swagger operation uses form data.
+
+## When to suggest another TSwagger surface
+
+- Suggest `@tswagger/cli` for CI, repeatable scripts, or batch generation without opening VS Code.
+- Suggest `@tswagger/core` for custom generators, agent tools, or deeper integration.
+- Suggest the output troubleshooting skill when the question is about unexpected generated names, imports, paths, or `service.map.yaml`.
+
+## Safety notes
+
+- Do not tell users to hand-edit `service.map.yaml` as a normal workflow. It preserves generated name mappings across regenerations.
+- Keep application-specific request-layer advice focused on `fetchFilePath` and the fetch helper contract.

--- a/skills/tswagger-output/SKILL.md
+++ b/skills/tswagger-output/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tswagger-output
+description: Use this skill when a developer needs to troubleshoot or explain tswagger generated TypeScript output, including service names, type names, imports, fetchFilePath, FetchResult, get/post/put/del helpers, basePath prefixes, basePathMapping, query/body/formData handling, or service.map.yaml behavior.
+---
+
+# TSwagger Generated Output
+
+Use this skill when the developer already generated files and wants to understand or fix the output. Start from the generated code and project config before recommending changes.
+
+## Triage order
+
+1. Identify which surface generated the files: VS Code extension, CLI, MCP, or custom `@tswagger/core` integration.
+2. Inspect the relevant generated service file and the source Swagger operation.
+3. Check project config for `fetchFilePath`, `addBasePathPrefix`, and `basePathMapping`.
+4. Check whether names come from `operationId`, path/method composition, translation, or existing mapping.
+5. If regeneration changed names unexpectedly, inspect `service.map.yaml`.
+
+## Generated service contract
+
+Service files are built around a fetch helper that exports:
+
+- `get`
+- `post`
+- `put`
+- `del`
+- `FetchResult`
+
+Swagger `delete` operations are emitted through `del` to avoid using `delete` as an imported function name.
+
+## Parameter shapes
+
+- Path params become direct function arguments and are interpolated into the URL.
+- Query params are passed as `query`.
+- Body params are passed as `data`.
+- Form data params are converted to `FormData` before request execution.
+- For `post`, `put`, and `delete`, query params may be appended to the URL with `URLSearchParams`.
+
+## Naming behavior
+
+- Prefer stable `operationId` values in Swagger documents when developers need stable service names.
+- If `operationId` is missing, TSwagger composes names from the HTTP method and path.
+- Chinese or non-ASCII names may be translated, depending on the surface and configuration.
+- Existing rename mappings can preserve names across regeneration.
+
+## Base path behavior
+
+- If `addBasePathPrefix` is false, generated request paths should not include the Swagger `basePath`.
+- If `addBasePathPrefix` is true and `basePathMapping` contains the Swagger `basePath`, the mapped value is used.
+- If `addBasePathPrefix` is true and there is no mapping, the Swagger `basePath` is prepended as-is.
+
+## service.map.yaml
+
+`service.map.yaml` records generated service/type mappings for a grouped API output. It lets TSwagger preserve renamed service and type names on later regeneration.
+
+Do not recommend manual edits as the default fix. Prefer regenerating through the extension rename flow or fixing the source Swagger naming. Manual edits are only appropriate when the developer explicitly understands they are migrating mappings.
+
+## Common fixes
+
+- Wrong import path: update `fetchFilePath` in project config, then regenerate.
+- Wrong URL prefix: update `addBasePathPrefix` or `basePathMapping`, then regenerate.
+- Unstable names: add stable `operationId` values, preserve translation cache, or use the extension rename workflow.
+- Missing form data handling: verify the fetch helper's `post` method supports `FormData`.


### PR DESCRIPTION
## Summary
- add five installable TSwagger skills for CLI, extension, generated output, core integration, and contributing workflows
- add skills.sh.json grouping for the skills.sh repo page
- include MCP package guidance in core/contributing skills after syncing latest master

## Validation
- npx skills add . --list
- npx skills use . --skill tswagger-cli
- npx skills use . --skill tswagger-contributing
- npx skills-ref validate skills/tswagger-cli
- npx skills-ref validate skills/tswagger-extension
- npx skills-ref validate skills/tswagger-output
- npx skills-ref validate skills/tswagger-core
- npx skills-ref validate skills/tswagger-contributing
- node JSON/frontmatter slug consistency check

## Notes
- no changeset is included because this does not change public npm package runtime behavior