### PR TITLE
fix(ci): recognize prerelease version PRs

### DIFF
--- a/.github/workflows/release-npm-test.yml
+++ b/.github/workflows/release-npm-test.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
     env:
+      NPM_VERSION_PR_BRANCH: 'changeset-release/master'
       NPM_VERSION_PR_TITLE: 'chore: version npm packages'
     steps:
       - name: Checkout
@@ -56,11 +57,35 @@ jobs:
       - name: Install Dependencies
         if: ${{ steps.npm_scope.outputs.should_validate == 'true' }}
         run: pnpm install --no-frozen-lockfile
+      - name: Detect Npm Version PR
+        id: version_pr
+        if: ${{ steps.npm_scope.outputs.should_validate == 'true' }}
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          const titlePattern = new RegExp(
+            `^${escapeRegExp(process.env.NPM_VERSION_PR_TITLE || '')}(?: \\([^)]+\\))?$`
+          );
+          const isNpmVersionPr =
+            process.env.GITHUB_EVENT_NAME === 'pull_request' &&
+            process.env.PR_HEAD_REF === process.env.NPM_VERSION_PR_BRANCH &&
+            titlePattern.test(process.env.PR_TITLE || '');
+
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `is_npm_version_pr=${isNpmVersionPr ? 'true' : 'false'}\n`
+          );
+          NODE
       - name: Validate Changeset Status
-        if: ${{ steps.npm_scope.outputs.should_validate == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.title != env.NPM_VERSION_PR_TITLE) }}
+        if: ${{ steps.npm_scope.outputs.should_validate == 'true' && steps.version_pr.outputs.is_npm_version_pr != 'true' }}
         run: pnpm run release:npm:status
       - name: Note Version PR Validation Mode
-        if: ${{ steps.npm_scope.outputs.should_validate == 'true' && github.event_name == 'pull_request' && github.event.pull_request.title == env.NPM_VERSION_PR_TITLE }}
+        if: ${{ steps.npm_scope.outputs.should_validate == 'true' && steps.version_pr.outputs.is_npm_version_pr == 'true' }}
         run: echo "Skipping changeset status because this PR is the maintainer-reviewed npm version PR."
       - name: Build Types
         if: ${{ steps.npm_scope.outputs.should_validate == 'true' }}

--- a/.github/workflows/validate-release-boundaries.yml
+++ b/.github/workflows/validate-release-boundaries.yml
@@ -24,6 +24,7 @@ jobs:
       pull-requests: read
     env:
       EXTENSION_RELEASE_PR_TITLE_PREFIX: 'chore: release extension '
+      NPM_VERSION_PR_BRANCH: 'changeset-release/master'
       NPM_VERSION_PR_TITLE: 'chore: version npm packages'
     steps:
       - name: Checkout
@@ -44,5 +45,6 @@ jobs:
       - name: Validate Boundaries
         env:
           CHANGED_FILES: ${{ steps.changed_files.outputs.files }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: node ./scripts/release/validate-release-boundaries.js

--- a/docs/release.md
+++ b/docs/release.md
@@ -145,7 +145,8 @@ After the version PR merge commit lands on `master`, the npm release workflow bu
 
 ## Release Boundary Checks
 
-- PRs that touch `packages/cli`, `packages/core`, or `packages/types` must include a `.changeset/*.md` file unless the PR is the npm version PR.
+- PRs that touch `packages/cli`, `packages/core`, `packages/mcp`, or `packages/types` must include a `.changeset/*.md` file unless the PR is the npm version PR from `changeset-release/master`.
+- npm version PR titles may be `chore: version npm packages` or include a prerelease tag suffix such as `chore: version npm packages (beta)`.
 - Extension Release PRs must not include `packages/*/package.json` or `packages/*/CHANGELOG.md`.
 - Conventional Commit scopes help reviewers understand intent, but path filters and PR checks are the enforcement layer.
 

--- a/scripts/release/validate-release-boundaries.js
+++ b/scripts/release/validate-release-boundaries.js
@@ -4,11 +4,18 @@ const changedFiles = (process.env.CHANGED_FILES || '')
   .filter(Boolean);
 
 const prTitle = process.env.PR_TITLE || '';
+const prHeadRef = process.env.PR_HEAD_REF || '';
 const npmVersionPrTitle = process.env.NPM_VERSION_PR_TITLE || 'chore: version npm packages';
+const npmVersionPrBranch = process.env.NPM_VERSION_PR_BRANCH || 'changeset-release/master';
 const extensionReleasePrTitlePrefix =
   process.env.EXTENSION_RELEASE_PR_TITLE_PREFIX || 'chore: release extension ';
 
-const isNpmVersionPr = prTitle === npmVersionPrTitle;
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const npmVersionPrTitlePattern = new RegExp(
+  `^${escapeRegExp(npmVersionPrTitle)}(?: \\([^)]+\\))?$`
+);
+const isNpmVersionPr =
+  prHeadRef === npmVersionPrBranch && npmVersionPrTitlePattern.test(prTitle);
 const isExtensionReleasePr = prTitle.startsWith(extensionReleasePrTitlePrefix);
 
 const isPublicPackageFile = (file) => /^packages\/(?:cli|core|types|mcp)\//.test(file);


### PR DESCRIPTION
## Summary
- recognize Changesets npm version PRs with prerelease title suffixes like `(beta)`
- require the expected `changeset-release/master` head branch before skipping changeset validation
- document prerelease version PR title handling in release docs

## Verification
- `node --check scripts/release/validate-release-boundaries.js`
- version PR smoke case passes for `chore: version npm packages (beta)` on `changeset-release/master`
- ordinary branch smoke case still fails without a changeset
- `git diff --cached --check`