### PR TITLE
style(webview): adapt UI to VS Code theme colors

### DIFF
--- a/webview/src/components/ApiGroupPanel/ApiGroupPanel.tsx
+++ b/webview/src/components/ApiGroupPanel/ApiGroupPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import styles from './ApiGroupPanel.less';
-import { Badge, Checkbox, Collapse, CollapsePanelProps, Empty, Space, Typography, theme } from 'antd';
+import { Badge, Checkbox, Collapse, CollapsePanelProps, Empty, Space, Typography } from 'antd';
 import { ApiGroupByTag, ApiPathType } from '@/utils/types';
 import { useSelections } from 'ahooks';
 import { OpenAPIV2 } from 'openapi-types';
@@ -32,7 +32,6 @@ const ApiGroupPanel: React.FC<ApiGroupPanelProps> = (props) => {
   const { className = '', apiGroupItem, onChange, ...otherProps } = props;
   const { refreshDocFlag, filters } = useContext(WebviewPageContext);
   const { tag, apiPathList } = apiGroupItem;
-  const { token } = theme.useToken();
   const { selected, toggleAll, unSelectAll, allSelected, partiallySelected, isSelected, toggle } = useSelections(apiPathList.map(genSelectKey));
 
   useEffect(() => {
@@ -74,7 +73,11 @@ const ApiGroupPanel: React.FC<ApiGroupPanelProps> = (props) => {
           <Text strong style={{ fontSize: 16 }}>
             {tag.name}
           </Text>
-          <Badge count={apiPathList.length} overflowCount={999} style={{ backgroundColor: token.colorSuccess }} />
+          <Badge
+            count={apiPathList.length}
+            overflowCount={999}
+            style={{ backgroundColor: 'var(--tswagger-badge-bg)', color: 'var(--tswagger-badge-fg)' }}
+          />
         </Space>
       }
     >

--- a/webview/src/components/MethodTag/MethodTag.less
+++ b/webview/src/components/MethodTag/MethodTag.less
@@ -1,4 +1,40 @@
 .root {
   width: 62px;
   text-align: center;
+  background: transparent;
+
+  &.methodGet {
+    color: var(--tswagger-success);
+    border-color: var(--tswagger-success);
+  }
+
+  &.methodPost {
+    color: var(--tswagger-link);
+    border-color: var(--tswagger-link);
+  }
+
+  &.methodPut {
+    color: var(--tswagger-warning);
+    border-color: var(--tswagger-warning);
+  }
+
+  &.methodDelete {
+    color: var(--tswagger-error);
+    border-color: var(--tswagger-error);
+  }
+
+  &.methodPatch {
+    color: var(--tswagger-info);
+    border-color: var(--tswagger-info);
+  }
+
+  &.methodOptions {
+    color: var(--tswagger-muted-fg);
+    border-color: var(--tswagger-muted-fg);
+  }
+
+  &.methodHead {
+    color: var(--tswagger-muted-fg);
+    border-color: var(--tswagger-muted-fg);
+  }
 }

--- a/webview/src/components/MethodTag/MethodTag.tsx
+++ b/webview/src/components/MethodTag/MethodTag.tsx
@@ -3,14 +3,14 @@ import styles from './MethodTag.less';
 import { Tag, TagProps } from 'antd';
 import { HttpMethod } from '@tswagger/types';
 
-const methodColorMap: Record<HttpMethod, TagProps['color']> = {
-  get: 'green',
-  post: 'blue',
-  put: 'yellow',
-  delete: 'red',
-  patch: 'purple',
-  options: 'geekblue',
-  head: 'cyan',
+const methodClassMap: Record<HttpMethod, string> = {
+  get: styles.methodGet,
+  post: styles.methodPost,
+  put: styles.methodPut,
+  delete: styles.methodDelete,
+  patch: styles.methodPatch,
+  options: styles.methodOptions,
+  head: styles.methodHead,
 };
 
 export interface MethodTagProps extends TagProps {
@@ -21,7 +21,7 @@ const MethodTag: React.FC<MethodTagProps> = (props) => {
   const { className = '', method, ...otherProps } = props;
 
   return (
-    <Tag className={`${styles.root} ${className}`} color={methodColorMap[method]} {...otherProps}>
+    <Tag className={`${styles.root} ${methodClassMap[method] ?? ''} ${className}`} {...otherProps}>
       {method.toUpperCase()}
     </Tag>
   );

--- a/webview/src/components/ProjectSwaggerUrlsModal/ProjectSwaggerUrlsModal.less
+++ b/webview/src/components/ProjectSwaggerUrlsModal/ProjectSwaggerUrlsModal.less
@@ -21,8 +21,8 @@
   gap: 16px;
   padding: 16px;
   border-radius: 8px;
-  border: 1px solid var(--vscode-widget-border, #303031);
-  background: var(--vscode-editorHoverWidget-background, #252526);
+  border: 1px solid var(--tswagger-border);
+  background: var(--tswagger-panel-bg);
 }
 
 .rowMain {
@@ -55,19 +55,19 @@
 
   &:hover,
   &:focus {
-    border-color: var(--vscode-focusBorder, #007fd4);
+    border-color: var(--tswagger-focus-border);
     transform: translateY(-1px);
     outline: none;
   }
 }
 
 .successIcon {
-  color: #52c41a;
+  color: var(--tswagger-success);
   margin-top: 3px;
 }
 
 .mutedIcon {
-  color: #8c8c8c;
+  color: var(--tswagger-muted-fg);
   margin-top: 3px;
 }
 
@@ -75,8 +75,8 @@
   margin-top: 16px;
   padding: 16px;
   border-radius: 8px;
-  border: 1px solid var(--vscode-widget-border, #303031);
-  background: var(--vscode-sideBar-background, #1e1e1e);
+  border: 1px solid var(--tswagger-border);
+  background: var(--tswagger-panel-bg);
 }
 
 .addTitle {

--- a/webview/src/components/SettingModal/SettingModal.less
+++ b/webview/src/components/SettingModal/SettingModal.less
@@ -10,9 +10,6 @@
       height: 70vh;
 
       :global {
-        .ant-menu-item {
-          background-color: transparent;
-        }
         .ant-menu-item-icon {
           font-size: 16px;
         }

--- a/webview/src/components/SettingModal/SettingModal.tsx
+++ b/webview/src/components/SettingModal/SettingModal.tsx
@@ -52,7 +52,6 @@ const SettingModal = (props: SettingModalProps) => {
       <div className={styles.container}>
         <Menu
           className={styles.menu}
-          theme="light"
           selectedKeys={[settingKey]}
           items={menuItems}
           onClick={(info) => {

--- a/webview/src/components/SkeletonLoader/SkeletonLoader.less
+++ b/webview/src/components/SkeletonLoader/SkeletonLoader.less
@@ -1,7 +1,7 @@
 .skeletonContainer {
   .skeletonCard {
-    background: var(--vscode-editorHoverWidget-background, #252526);
-    border: 1px solid var(--vscode-widget-border, #303031);
+    background: var(--tswagger-panel-bg);
+    border: 1px solid var(--tswagger-border);
     border-radius: 12px;
     margin-bottom: 16px;
     padding: 12px;
@@ -9,35 +9,40 @@
     &:last-child {
       margin-bottom: 0;
     }
-
-    :global(.ant-skeleton-element) {
-      .ant-skeleton-input {
-        background: var(--vscode-editorWidget-background, #2d2d30);
-        border-radius: 6px;
-      }
-
-      .ant-skeleton-button {
-        background: var(--vscode-editorWidget-background, #2d2d30);
-        border-radius: 6px;
-      }
-    }
   }
   .skeletonContent {
     margin-top: 12px;
   }
 
-  :global(.ant-skeleton.ant-skeleton-active) {
-    .ant-skeleton-content {
-      .ant-skeleton-title,
-      .ant-skeleton-paragraph > li {
-        background: linear-gradient(
-          90deg,
-          var(--vscode-editorWidget-background, #2d2d30) 25%,
-          var(--vscode-editor-background, #1e1e1e) 37%,
-          var(--vscode-editorWidget-background, #2d2d30) 63%
-        );
-        background-size: 400% 100%;
-        animation: ant-skeleton-loading 1.4s ease infinite;
+  // 注意：类名选择器必须放在 :global 块内，否则会被 CSS Modules 哈希
+  :global {
+    // 骨架条使用列表悬停色：editorWidget 背景在部分主题下与卡片底色一致，
+    // 会导致骨架条“融为一体”不可见
+    .ant-skeleton-element {
+      .ant-skeleton-input {
+        background: var(--tswagger-hover-bg);
+        border-radius: 6px;
+      }
+
+      .ant-skeleton-button {
+        background: var(--tswagger-hover-bg);
+        border-radius: 6px;
+      }
+    }
+
+    .ant-skeleton.ant-skeleton-active {
+      .ant-skeleton-content {
+        .ant-skeleton-title,
+        .ant-skeleton-paragraph > li {
+          background: linear-gradient(
+            90deg,
+            var(--tswagger-hover-bg) 25%,
+            var(--tswagger-active-bg) 37%,
+            var(--tswagger-hover-bg) 63%
+          );
+          background-size: 400% 100%;
+          animation: ant-skeleton-loading 1.4s ease infinite;
+        }
       }
     }
   }

--- a/webview/src/components/SwaggerDocDrawer/SwaggerDocDrawer.module.less
+++ b/webview/src/components/SwaggerDocDrawer/SwaggerDocDrawer.module.less
@@ -17,9 +17,9 @@
     }
 
     &.dragOver {
-      border: 2px dashed #1890ff;
+      border: 2px dashed var(--tswagger-focus-border);
       border-radius: 6px;
-      background-color: rgba(24, 144, 255, 0.05);
+      background-color: var(--tswagger-hover-bg);
     }
 
     &[draggable='false'] {
@@ -59,7 +59,7 @@
       }
 
       .docCount {
-        color: #8c8c8c;
+        color: var(--tswagger-muted-fg);
         font-size: 12px;
       }
     }
@@ -68,10 +68,10 @@
   .legacyContent {
     .legacyTip {
       padding: 12px;
-      background: #fff7e6;
-      border: 1px solid #ffd591;
+      background: transparent;
+      border: 1px solid var(--tswagger-warning);
       border-radius: 6px;
-      color: #d46b08;
+      color: var(--tswagger-warning);
       margin-bottom: 16px;
     }
 

--- a/webview/src/components/SwaggerDocDrawer/SwaggerDocDrawer.tsx
+++ b/webview/src/components/SwaggerDocDrawer/SwaggerDocDrawer.tsx
@@ -601,7 +601,7 @@ const SwaggerDocDrawer = (props: SwaggerDocDrawerProps) => {
                     extra={
                       <Space
                         size="small"
-                        split={group.id !== UNGROUPED_ID ? <span style={{ color: '#d9d9d9' }}>|</span> : undefined}
+                        split={group.id !== UNGROUPED_ID ? <span style={{ color: token.colorBorderSecondary }}>|</span> : undefined}
                         onClick={(e) => {
                           e.stopPropagation();
                         }}
@@ -611,7 +611,7 @@ const SwaggerDocDrawer = (props: SwaggerDocDrawerProps) => {
                           icon={<PlusOutlined />}
                           title="添加文档"
                           onClick={() => handleAddDocToGroup(group.id)}
-                          style={{ color: '#1890ff' }}
+                          style={{ color: token.colorInfo }}
                         />
                         {/* 分组操作 */}
                         {group.id !== UNGROUPED_ID && (
@@ -621,13 +621,13 @@ const SwaggerDocDrawer = (props: SwaggerDocDrawerProps) => {
                               title="编辑分组名称"
                               onClick={() => setEditingGroupId(group.id)}
                               type="text"
-                              style={{ color: '#52c41a' }}
+                              style={{ color: token.colorSuccess }}
                             />
                             <ActionIcon
                               icon={<DeleteOutlined />}
                               title="删除分组"
                               type="text"
-                              style={{ color: '#ff4d4f' }}
+                              style={{ color: token.colorError }}
                               onClick={() => handleDeleteGroup(group.id)}
                             />
                           </>

--- a/webview/src/components/SwaggerInfo/SwaggerInfo.tsx
+++ b/webview/src/components/SwaggerInfo/SwaggerInfo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { OpenAPIV2 } from 'openapi-types';
 import styles from './SwaggerInfo.less';
-import { Badge, Collapse, Descriptions, Tag, theme, Typography } from 'antd';
+import { Badge, Collapse, Descriptions, Tag, Typography } from 'antd';
 import { CaretRightOutlined } from '@ant-design/icons';
 
 export interface SwaggerInfoProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -11,11 +11,9 @@ export interface SwaggerInfoProps extends React.HTMLAttributes<HTMLDivElement> {
 const SwaggerInfo: React.FC<SwaggerInfoProps> = (props) => {
   const { className = '', v2Doc, ...otherProps } = props;
 
-  const { token } = theme.useToken();
-
   return (
     <div className={`${styles.root} ${className}`} {...otherProps}>
-      <Badge.Ribbon text={`OpenAPI ${v2Doc.swagger} 规范`} color={token.colorPrimaryActive}>
+      <Badge.Ribbon text={`OpenAPI ${v2Doc.swagger} 规范`} color="var(--tswagger-badge-bg)">
         <Collapse size="large" expandIcon={({ isActive }) => <CaretRightOutlined rotate={isActive ? 90 : 0} />}>
           <Collapse.Panel key="swaggerOverview" header={`【文档信息】${v2Doc.info.title}`}>
             <Descriptions title="">

--- a/webview/src/components/TsGenerateSpin/TsGenerateSpin.less
+++ b/webview/src/components/TsGenerateSpin/TsGenerateSpin.less
@@ -46,18 +46,18 @@
     .loading {
       display: block;
       font-size: 0;
-      color: #000;
+      color: var(--tswagger-fg);
     }
 
     .loading.la-dark {
-      color: #333;
+      color: var(--tswagger-muted-fg);
     }
 
     .loading > div {
       display: inline-block;
       float: none;
-      background-color: #85ea2d;
-      border: 0 solid #85ea2d;
+      background-color: var(--tswagger-brand-green);
+      border: 0 solid var(--tswagger-brand-green);
     }
 
     .loading {
@@ -71,8 +71,8 @@
       left: 18%;
       width: 18px;
       height: 18px;
-      background-color: #3178c6;
-      border: 0 solid #3178c6;
+      background-color: var(--tswagger-brand-blue);
+      border: 0 solid var(--tswagger-brand-blue);
       border-radius: 100%;
       transform-origin: center bottom;
       animation: ball-climbing-dot-jump 0.6s ease-in-out infinite;

--- a/webview/src/components/TsResultModal/TsResultModal.tsx
+++ b/webview/src/components/TsResultModal/TsResultModal.tsx
@@ -15,6 +15,7 @@ import notification from '@/utils/notification';
 import { OpenAPIV2 } from 'openapi-types';
 import { useGlobalState } from '@/states/globalState';
 import { apiReadServiceMapInfo } from '@/services';
+import useVsCodeThemeKind from '@/hooks/useVsCodeThemeKind';
 
 const { Text } = Typography;
 
@@ -48,6 +49,7 @@ const TsResultModal: React.FC<TsResultModalProps> = (props) => {
 
   const currentBasePath = V2Docs?.basePath ?? '';
   const { token } = theme.useToken();
+  const monacoTheme = useVsCodeThemeKind();
   const drawer = usePromisifyDrawer();
   const { tswaggerConfig } = useGlobalState();
   const mappedBasePathList = Object.keys(tswaggerConfig.basePathMapping ?? {});
@@ -266,7 +268,7 @@ const TsResultModal: React.FC<TsResultModalProps> = (props) => {
             <MonacoEditor
               value={editorContent.originalContent}
               height="75vh"
-              theme="vs-dark"
+              theme={monacoTheme}
               language="typescript"
               options={{
                 readOnly: true,
@@ -279,7 +281,7 @@ const TsResultModal: React.FC<TsResultModalProps> = (props) => {
               original={editorContent.originalContent}
               modified={editorContent.modifiedContent}
               height="75vh"
-              theme="vs-dark"
+              theme={monacoTheme}
               language="typescript"
               options={{
                 readOnly: true,

--- a/webview/src/global.less
+++ b/webview/src/global.less
@@ -1,11 +1,81 @@
+// Semantic theme variables bridging VS Code webview theme tokens.
+//
+// 重要：VS Code 只向 webview 注入主题「显式定义」的颜色（不含注册表默认值），
+// 因此 hex 兜底值不仅在 webview 之外生效，也会在主题未定义对应颜色时生效——
+// 所有兜底必须在亮/暗两种背景下都保证可读。
+:root {
+  --tswagger-bg: var(--vscode-editor-background, #ffffff);
+  --tswagger-fg: var(--vscode-foreground, #1f1f1f);
+  --tswagger-muted-fg: var(--vscode-descriptionForeground, #6a6a6a);
+  --tswagger-panel-bg: var(--vscode-sideBar-background, var(--vscode-editor-background, #ffffff));
+  --tswagger-elevated-bg: var(--vscode-editorWidget-background, var(--vscode-sideBar-background, #ffffff));
+  --tswagger-hover-bg: var(--vscode-list-hoverBackground, var(--vscode-toolbar-hoverBackground, transparent));
+  --tswagger-active-bg: var(--vscode-list-activeSelectionBackground, var(--vscode-button-background, #0e639c));
+  --tswagger-border: var(--vscode-widget-border, var(--vscode-panel-border, #d0d0d0));
+  --tswagger-focus-border: var(--vscode-focusBorder, #0078d4);
+  --tswagger-link: var(--vscode-textLink-foreground, #006ab1);
+  --tswagger-button-bg: var(--vscode-button-background, #0e639c);
+  --tswagger-button-fg: var(--vscode-button-foreground, #ffffff);
+  --tswagger-button-hover-bg: var(--vscode-button-hoverBackground, #1177bb);
+  --tswagger-input-bg: var(--vscode-input-background, var(--tswagger-elevated-bg));
+  --tswagger-input-fg: var(--vscode-input-foreground, var(--tswagger-fg));
+  --tswagger-input-border: var(--vscode-input-border, var(--tswagger-border));
+  // 状态色优先使用编辑器波浪线/图表色（按设计必须在小尺寸下可见）。
+  // 注意：VS Code 只向 webview 注入主题「显式定义」的颜色（注入逻辑里
+  // getColor 不带 useDefault），注册表默认值不会出现；而 errorForeground、
+  // testing.iconPassed、list.warningForeground 这类语义色在部分主题中
+  // 被显式定义为暗色，因此不能直接放进链式兜底——会挤占后面的亮色兜底。
+  --tswagger-success: var(--vscode-charts-green, #2da44e);
+  --tswagger-warning: var(--vscode-editorWarning-foreground, #cca700);
+  --tswagger-error: var(--vscode-editorError-foreground, #f14c4c);
+  --tswagger-info: var(--vscode-editorInfo-foreground, #3794ff);
+  --tswagger-badge-bg: var(--vscode-badge-background, var(--tswagger-focus-border));
+  --tswagger-badge-fg: var(--vscode-badge-foreground, #ffffff);
+
+  // Intentional brand colors, kept in sync with the logo asset.
+  --tswagger-brand-green: #85ea2d;
+  --tswagger-brand-blue: #3178c6;
+}
+
 html,
 body,
 #root {
   margin: 0;
   padding: 0;
   min-height: 100vh;
+  background-color: var(--tswagger-bg);
+  color: var(--tswagger-fg);
+  font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-size: var(--vscode-font-size, 13px);
 }
 
 #root {
   position: relative;
+}
+
+// antd 浮层（下拉/弹窗/抽屉/通知等）默认没有边框、依赖投影分层；
+// 主题已禁用投影（boxShadow: none），改用 VS Code widget 边框与页面分隔，
+// 与编辑器原生 hover/suggest 控件的观感一致。
+.ant-select-dropdown,
+.ant-dropdown-menu,
+.ant-popover .ant-popover-inner,
+.ant-tooltip .ant-tooltip-inner,
+.ant-modal .ant-modal-content,
+.ant-drawer .ant-drawer-content,
+.ant-notification .ant-notification-notice,
+.ant-message .ant-message-notice-content {
+  border: 1px solid var(--tswagger-border);
+}
+
+// Typography 可编辑/复制触发图标：antd 默认使用链接色，在部分主题下
+// 偏暗几乎不可见，统一改用编辑器前景色（重复类名用于提升优先级，
+// 覆盖 antd 运行时注入的同优先级规则）
+.ant-typography .ant-typography-edit.ant-typography-edit,
+.ant-typography .ant-typography-copy.ant-typography-copy {
+  color: var(--tswagger-fg);
+
+  &:hover,
+  &:focus {
+    color: var(--tswagger-link);
+  }
 }

--- a/webview/src/hooks/useVsCodeThemeColors.ts
+++ b/webview/src/hooks/useVsCodeThemeColors.ts
@@ -1,0 +1,348 @@
+import { useEffect, useState } from 'react';
+
+const FONT_FAMILY_FALLBACK =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+
+type ThemeKind = 'dark' | 'light';
+
+export interface VsCodeThemeColors {
+  fontFamily: string;
+  editorBg: string;
+  fg: string;
+  mutedFg: string;
+  panelBg: string;
+  elevatedBg: string;
+  hoverBg: string;
+  activeBg: string;
+  border: string;
+  focusBorder: string;
+  link: string;
+  linkActive: string;
+  buttonBg: string;
+  buttonFg: string;
+  buttonHoverBg: string;
+  inputBg: string;
+  inputFg: string;
+  inputBorder: string;
+  success: string;
+  warning: string;
+  error: string;
+  info: string;
+  badgeBg: string;
+  badgeFg: string;
+}
+
+const FALLBACKS: Record<ThemeKind, VsCodeThemeColors> = {
+  dark: {
+    fontFamily: FONT_FAMILY_FALLBACK,
+    editorBg: '#1e1e1e',
+    fg: '#cccccc',
+    mutedFg: '#999999',
+    panelBg: '#252526',
+    elevatedBg: '#252526',
+    hoverBg: '#2a2d2e',
+    activeBg: '#094771',
+    border: '#454545',
+    focusBorder: '#007fd4',
+    link: '#3794ff',
+    linkActive: '#3794ff',
+    buttonBg: '#0e639c',
+    buttonFg: '#ffffff',
+    buttonHoverBg: '#1177bb',
+    inputBg: '#3c3c3c',
+    inputFg: '#cccccc',
+    inputBorder: '#454545',
+    success: '#2da44e',
+    warning: '#cca700',
+    error: '#f14c4c',
+    info: '#3794ff',
+    badgeBg: '#4d4d4d',
+    badgeFg: '#ffffff',
+  },
+  light: {
+    fontFamily: FONT_FAMILY_FALLBACK,
+    editorBg: '#ffffff',
+    fg: '#1f1f1f',
+    mutedFg: '#6a6a6a',
+    panelBg: '#f3f3f3',
+    elevatedBg: '#f3f3f3',
+    hoverBg: '#e8e8e8',
+    activeBg: '#0060c0',
+    border: '#c8c8c8',
+    focusBorder: '#0078d4',
+    link: '#006ab1',
+    linkActive: '#006ab1',
+    buttonBg: '#0078d4',
+    buttonFg: '#ffffff',
+    buttonHoverBg: '#106ba3',
+    inputBg: '#ffffff',
+    inputFg: '#1f1f1f',
+    inputBorder: '#c8c8c8',
+    success: '#1a7f37',
+    warning: '#bf8803',
+    error: '#d13438',
+    info: '#006ab1',
+    badgeBg: '#c4c4c4',
+    badgeFg: '#333333',
+  },
+};
+
+function getThemeKind(): ThemeKind {
+  if (typeof document === 'undefined') {
+    return 'dark';
+  }
+  const classList = document.body.classList;
+  if (
+    classList.contains('vscode-light') ||
+    classList.contains('vscode-high-contrast-light')
+  ) {
+    return 'light';
+  }
+  return 'dark';
+}
+
+function readCssVar(
+  bodyStyle: CSSStyleDeclaration,
+  rootStyle: CSSStyleDeclaration,
+  name: string,
+) {
+  return (
+    bodyStyle.getPropertyValue(name).trim() ||
+    rootStyle.getPropertyValue(name).trim()
+  );
+}
+
+function pickCssVar(
+  bodyStyle: CSSStyleDeclaration,
+  rootStyle: CSSStyleDeclaration,
+  names: string[],
+  fallback: string,
+) {
+  for (const name of names) {
+    const value = readCssVar(bodyStyle, rootStyle, name);
+    if (value) {
+      return value;
+    }
+  }
+  return fallback;
+}
+
+function areColorsEqual(
+  prev: VsCodeThemeColors,
+  next: VsCodeThemeColors,
+): boolean {
+  return (Object.keys(prev) as Array<keyof VsCodeThemeColors>).every(
+    (key) => prev[key] === next[key],
+  );
+}
+
+function getVsCodeThemeColors(): VsCodeThemeColors {
+  const fallbacks = FALLBACKS[getThemeKind()];
+  if (typeof document === 'undefined') {
+    return fallbacks;
+  }
+
+  const bodyStyle = getComputedStyle(document.body);
+  const rootStyle = getComputedStyle(document.documentElement);
+  const editorBg = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-editor-background'],
+    fallbacks.editorBg,
+  );
+  const fg = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-foreground'],
+    fallbacks.fg,
+  );
+  const mutedFg = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-descriptionForeground'],
+    fallbacks.mutedFg,
+  );
+  const panelBg = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-sideBar-background'],
+    editorBg || fallbacks.panelBg,
+  );
+  const elevatedBg = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-editorWidget-background', '--vscode-sideBar-background'],
+    panelBg || fallbacks.elevatedBg,
+  );
+  const border = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-widget-border', '--vscode-panel-border'],
+    fallbacks.border,
+  );
+  const focusBorder = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-focusBorder'],
+    fallbacks.focusBorder,
+  );
+  const link = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-textLink-foreground'],
+    fallbacks.link,
+  );
+  const linkActive = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-textLink-activeForeground'],
+    link || fallbacks.linkActive,
+  );
+  const inputFg = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-input-foreground'],
+    fg || fallbacks.inputFg,
+  );
+  const inputBorder = pickCssVar(
+    bodyStyle,
+    rootStyle,
+    ['--vscode-input-border'],
+    border || fallbacks.inputBorder,
+  );
+
+  return {
+    fontFamily: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-font-family'],
+      fallbacks.fontFamily,
+    ),
+    editorBg,
+    fg,
+    mutedFg,
+    panelBg,
+    elevatedBg,
+    hoverBg: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-list-hoverBackground'],
+      fallbacks.hoverBg,
+    ),
+    activeBg: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-list-activeSelectionBackground', '--vscode-button-background'],
+      fallbacks.activeBg,
+    ),
+    border,
+    focusBorder,
+    link,
+    linkActive,
+    buttonBg: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-button-background'],
+      fallbacks.buttonBg,
+    ),
+    buttonFg: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-button-foreground'],
+      fallbacks.buttonFg,
+    ),
+    buttonHoverBg: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-button-hoverBackground'],
+      fallbacks.buttonHoverBg,
+    ),
+    inputBg: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-input-background'],
+      fallbacks.inputBg,
+    ),
+    inputFg,
+    inputBorder,
+    // Avoid semantic fallback chains such as errorForeground or testing icons:
+    // some themes define them as dark colors that are unreadable in tiny icons.
+    success: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-charts-green'],
+      fallbacks.success,
+    ),
+    warning: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-editorWarning-foreground'],
+      fallbacks.warning,
+    ),
+    error: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-editorError-foreground'],
+      fallbacks.error,
+    ),
+    info: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-editorInfo-foreground'],
+      fallbacks.info,
+    ),
+    badgeBg: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-badge-background'],
+      fallbacks.badgeBg,
+    ),
+    badgeFg: pickCssVar(
+      bodyStyle,
+      rootStyle,
+      ['--vscode-badge-foreground'],
+      fallbacks.badgeFg,
+    ),
+  };
+}
+
+export default function useVsCodeThemeColors(): VsCodeThemeColors {
+  const [colors, setColors] = useState<VsCodeThemeColors>(getVsCodeThemeColors);
+
+  useEffect(() => {
+    let animationFrameId = 0;
+
+    const syncColors = () => {
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+      animationFrameId = requestAnimationFrame(() => {
+        setColors((prev) => {
+          const next = getVsCodeThemeColors();
+          return areColorsEqual(prev, next) ? prev : next;
+        });
+      });
+    };
+
+    const observer = new MutationObserver(syncColors);
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+    observer.observe(document.head, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    syncColors();
+
+    return () => {
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+      observer.disconnect();
+    };
+  }, []);
+
+  return colors;
+}

--- a/webview/src/hooks/useVsCodeThemeKind.ts
+++ b/webview/src/hooks/useVsCodeThemeKind.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Monaco built-in theme names that mirror the current VS Code webview theme.
+ * VS Code applies one of `vscode-light` / `vscode-dark` / `vscode-high-contrast`
+ * (or `vscode-high-contrast-light`) on the webview `body`.
+ */
+export type VsCodeMonacoTheme = 'vs' | 'vs-dark' | 'hc-black' | 'hc-light';
+
+function getMonacoThemeFromBody(): VsCodeMonacoTheme {
+  const classList = document.body.classList;
+  if (classList.contains('vscode-high-contrast-light')) {
+    return 'hc-light';
+  }
+  if (classList.contains('vscode-high-contrast')) {
+    return 'hc-black';
+  }
+  if (classList.contains('vscode-light')) {
+    return 'vs';
+  }
+  return 'vs-dark';
+}
+
+/**
+ * Maps the VS Code webview body theme class to a Monaco built-in theme and
+ * keeps it in sync while the webview is open (e.g. when the user switches the
+ * editor color theme without reloading the webview).
+ */
+export default function useVsCodeThemeKind(): VsCodeMonacoTheme {
+  const [monacoTheme, setMonacoTheme] = useState<VsCodeMonacoTheme>(getMonacoThemeFromBody);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setMonacoTheme(getMonacoThemeFromBody());
+    });
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return monacoTheme;
+}

--- a/webview/src/layouts/index.tsx
+++ b/webview/src/layouts/index.tsx
@@ -1,12 +1,114 @@
-import { ConfigProvider, theme } from 'antd';
+import { ConfigProvider } from 'antd';
+import type { ThemeConfig } from 'antd';
 import zhCN from 'antd/locale/zh_CN';
 import { HoxRoot } from 'hox';
+import { useMemo } from 'react';
 import { Outlet } from 'umi';
+import useVsCodeThemeColors from '@/hooks/useVsCodeThemeColors';
+import type { VsCodeThemeColors } from '@/hooks/useVsCodeThemeColors';
 import styles from './index.less';
 
+/**
+ * Ant Design derives many alias colors in JS, so token colors must be concrete
+ * values instead of CSS var() strings. The hook resolves VS Code webview CSS
+ * variables at runtime before they enter antd's color pipeline.
+ */
+function buildAntdTheme(colors: VsCodeThemeColors): ThemeConfig {
+  return {
+    token: {
+      colorBgBase: colors.editorBg,
+      colorTextBase: colors.fg,
+      colorBgLayout: colors.editorBg,
+      colorBgContainer: colors.panelBg,
+      colorBgElevated: colors.elevatedBg,
+      colorBorder: colors.border,
+      colorBorderSecondary: colors.border,
+      colorSplit: colors.border,
+      colorPrimary: colors.buttonBg,
+      colorPrimaryText: colors.link,
+      colorPrimaryTextHover: colors.linkActive,
+      colorPrimaryTextActive: colors.linkActive,
+      colorLink: colors.link,
+      colorLinkHover: colors.linkActive,
+      colorLinkActive: colors.linkActive,
+      colorSuccess: colors.success,
+      colorWarning: colors.warning,
+      colorError: colors.error,
+      colorInfo: colors.info,
+      fontFamily: colors.fontFamily,
+      fontSize: 13,
+      borderRadius: 4,
+      boxShadow: 'none',
+      boxShadowSecondary: 'none',
+      boxShadowTertiary: 'none',
+    },
+    components: {
+      Button: {
+        primaryColor: colors.buttonFg,
+      },
+      Input: {
+        colorBgContainer: colors.inputBg,
+        colorText: colors.inputFg,
+        colorBorder: colors.inputBorder,
+        hoverBorderColor: colors.focusBorder,
+        activeBorderColor: colors.focusBorder,
+        activeShadow: 'none',
+      },
+      Select: {
+        colorBgContainer: colors.inputBg,
+        colorText: colors.inputFg,
+        colorTextPlaceholder: colors.mutedFg,
+        colorBorder: colors.inputBorder,
+        selectorBg: colors.inputBg,
+        clearBg: colors.inputBg,
+        hoverBorderColor: colors.focusBorder,
+        activeBorderColor: colors.focusBorder,
+        activeOutlineColor: 'transparent',
+        optionActiveBg: colors.hoverBg,
+        optionSelectedBg: colors.hoverBg,
+        optionSelectedColor: colors.fg,
+      },
+      Modal: {
+        contentBg: colors.elevatedBg,
+        headerBg: colors.elevatedBg,
+        footerBg: colors.elevatedBg,
+      },
+      Menu: {
+        itemSelectedBg: colors.activeBg,
+        itemSelectedColor: colors.fg,
+        itemHoverBg: colors.hoverBg,
+      },
+      Tabs: {
+        itemSelectedColor: colors.link,
+        itemHoverColor: colors.linkActive,
+        itemActiveColor: colors.linkActive,
+        inkBarColor: colors.focusBorder,
+      },
+      Checkbox: {
+        colorPrimary: colors.link,
+        colorPrimaryHover: colors.linkActive,
+        colorWhite: colors.buttonFg,
+        colorBgContainer: 'transparent',
+        colorBorder: colors.focusBorder,
+      },
+      Badge: {
+        colorTextLightSolid: colors.badgeFg,
+      },
+      Tooltip: {
+        colorBgSpotlight: colors.elevatedBg,
+        colorTextLightSolid: colors.fg,
+        boxShadowSecondary: 'none',
+      },
+    },
+  };
+}
+
 export default function Layout() {
+  const colors = useVsCodeThemeColors();
+  const vsCodeTheme = useMemo(() => buildAntdTheme(colors), [colors]);
+
   return (
-    <ConfigProvider theme={{ algorithm: theme.darkAlgorithm }} locale={zhCN}>
+    <ConfigProvider theme={vsCodeTheme} locale={zhCN}>
       <HoxRoot>
         <div className={styles.root}>
           <Outlet />

--- a/webview/src/pages/WebviewPage.less
+++ b/webview/src/pages/WebviewPage.less
@@ -5,8 +5,8 @@
   flex-direction: column;
 
   .header {
-    background: linear-gradient(135deg, var(--vscode-editorHoverWidget-background, #252526) 0%, var(--vscode-editor-background, #1e1e1e) 100%);
-    border-bottom: 1px solid var(--vscode-widget-border, #303031);
+    background: var(--tswagger-panel-bg);
+    border-bottom: 1px solid var(--tswagger-border);
     padding: 0 32px;
     height: 72px;
     display: flex;
@@ -33,16 +33,12 @@
           margin: 0;
           font-size: 22px;
           font-weight: 600;
-          color: var(--vscode-foreground, #cccccc);
-          background: linear-gradient(135deg, #85ea2d 0%, #3178c6 100%);
-          background-clip: text;
-          -webkit-background-clip: text;
-          -webkit-text-fill-color: transparent;
+          color: var(--tswagger-fg);
         }
 
         .subtitle {
           font-size: 12px;
-          color: var(--vscode-descriptionForeground, #999999);
+          color: var(--tswagger-muted-fg);
           display: block;
           margin-top: 2px;
         }
@@ -51,14 +47,14 @@
 
     .headerActions {
       .headerButton {
-        color: var(--vscode-foreground, #cccccc);
-        border: 1px solid var(--vscode-widget-border, #303031);
+        color: var(--tswagger-fg);
+        border: 1px solid var(--tswagger-border);
         border-radius: 6px;
         transition: all 0.2s ease;
 
         &:hover {
-          background-color: var(--vscode-button-hoverBackground, #2c2c2c);
-          border-color: var(--vscode-focusBorder, #007acc);
+          background-color: var(--tswagger-hover-bg);
+          border-color: var(--tswagger-focus-border);
         }
       }
     }
@@ -73,44 +69,36 @@
     padding: 16px 32px;
     margin-top: 0;
 
-    .empty {
-      height: 50vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: var(--vscode-editorHoverWidget-background, #252526);
-      border-radius: 12px;
-      border: 1px solid var(--vscode-widget-border, #303031);
+    .emptyDescription {
+      text-align: center;
+      color: var(--tswagger-fg);
 
-      .emptyDescription {
-        text-align: center;
-        color: var(--vscode-foreground, #cccccc);
-
-        .emptyHint {
-          margin-top: 8px;
-          font-size: 12px;
-          color: var(--vscode-descriptionForeground, #999999);
-        }
+      .emptyHint {
+        margin-top: 8px;
+        font-size: 12px;
+        color: var(--tswagger-muted-fg);
       }
+    }
 
-      :global(.ant-empty-image) {
-        svg {
-          fill: var(--vscode-descriptionForeground, #999999);
-        }
+    // antd Empty 插图颜色取自 colorBgContainer/colorFill 背景系 token，
+    // 在部分主题下近似纯黑；统一改用次级文字色，保证亮/暗主题均可见
+    :global(.ant-empty-image) {
+      path,
+      ellipse {
+        fill: var(--tswagger-muted-fg);
       }
     }
 
     .content {
       padding: 20px 24px;
       border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-      background: var(--vscode-editorHoverWidget-background, #252526);
-      border: 1px solid var(--vscode-widget-border, #303031);
-      transition: box-shadow 0.2s ease;
+      background: var(--tswagger-panel-bg);
+      border: 1px solid var(--tswagger-border);
+      transition: border-color 0.2s ease;
       flex-shrink: 0;
 
       &:hover {
-        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+        border-color: var(--tswagger-focus-border);
       }
 
       .localFileBtn {
@@ -118,12 +106,28 @@
         margin: 12px 0 24px 0;
       }
 
+      // 表单 label 内的行内操作图标：直接使用编辑器前景色保证可见，
+      // 避免 accent/warning 色在小尺寸图标上偏暗看不清。
+      // 注意：类名选择器必须放在 :global 块内，否则会被 CSS Modules 哈希
+      :global {
+        .ant-form-item-label {
+          .ant-btn:not(:disabled) {
+            color: var(--tswagger-fg);
+
+            &:hover,
+            &:focus {
+              color: var(--tswagger-link);
+            }
+          }
+        }
+      }
+
       .actionBar {
         display: flex;
         align-items: center;
         margin-top: 16px;
         padding-top: 16px;
-        border-top: 1px solid var(--vscode-widget-border, #303031);
+        border-top: 1px solid var(--tswagger-border);
 
         &.collapse {
           margin: 0;
@@ -135,11 +139,11 @@
           flex: 1;
 
           .statsText {
-            color: var(--vscode-foreground, #cccccc);
+            color: var(--tswagger-fg);
             font-size: 14px;
 
             strong {
-              color: var(--vscode-focusBorder, #007acc);
+              color: var(--tswagger-focus-border);
               font-weight: 600;
             }
           }
@@ -149,9 +153,9 @@
 
     .swaggerInfo {
       margin-top: 16px;
-      background: var(--vscode-editorHoverWidget-background, #252526);
+      background: var(--tswagger-panel-bg);
       border-radius: 12px;
-      border: 1px solid var(--vscode-widget-border, #303031);
+      border: 1px solid var(--tswagger-border);
       overflow: hidden;
       flex-shrink: 0;
     }
@@ -159,12 +163,12 @@
     .quickActions {
       margin-top: 16px;
       padding: 12px 16px;
-      background: var(--vscode-editorWidget-background, #2d2d30);
+      background: var(--tswagger-elevated-bg);
       border-radius: 8px;
-      border: 1px solid var(--vscode-widget-border, #303031);
+      border: 1px solid var(--tswagger-border);
 
       .quickActionsLabel {
-        color: var(--vscode-foreground, #cccccc);
+        color: var(--tswagger-fg);
         font-size: 13px;
         font-weight: 500;
       }
@@ -179,6 +183,6 @@
   }
 
   :global(.ant-layout) {
-    background-color: var(--vscode-editor-background, #1e1e1e);
+    background-color: var(--tswagger-bg);
   }
 }

--- a/webview/src/pages/WebviewPage.tsx
+++ b/webview/src/pages/WebviewPage.tsx
@@ -357,13 +357,7 @@ const WebviewPage: React.FC<WebviewPageProps> = (props) => {
           </header>
         </Affix>
         <Layout ref={scrollContainerRef} className={styles.layout} style={{ flex: 1, overflow: 'auto' }}>
-          <Content
-            className={styles.content}
-            style={{
-              border: `1px solid var(--vscode-widget-border, #303031)`,
-              backgroundColor: 'var(--vscode-editorHoverWidget-background, #252526)',
-            }}
-          >
+          <Content className={styles.content}>
             <Form form={form} layout="vertical" {...formItemLayout} style={{ overflow: 'hidden', height: expand ? 'unset' : 0 }}>
               <Tabs
                 defaultActiveKey={PARSE_METHOD_DOCS}
@@ -398,7 +392,7 @@ const WebviewPage: React.FC<WebviewPageProps> = (props) => {
                             <ActionIcon
                               icon={<FormOutlined />}
                               title="管理文档地址"
-                              style={{ display: 'inline-block', color: '#fa8c16' }}
+                              style={{ display: 'inline-block' }}
                               onClick={() => {
                                 drawer.show(
                                   <SwaggerDocDrawer
@@ -496,7 +490,7 @@ const WebviewPage: React.FC<WebviewPageProps> = (props) => {
                   icon={<DownOutlined rotate={expand ? 180 : 0} />}
                   onClick={toggleExpand}
                   title={expand ? '收起' : '展开'}
-                  style={{ color: '#8c8c8c' }}
+                  style={{ color: token.colorTextTertiary }}
                 />
               </Space>
             </div>


### PR DESCRIPTION
## Summary

Adapts the webview UI to VS Code theme colors by resolving webview CSS variables into concrete Ant Design theme tokens at runtime, avoiding invalid antd color derivation from `var(...)` values.

## Type

- [ ] Feature
- [x] Fix (bug fix)
- [ ] Chore (maintenance, dependencies, config)
- [ ] Docs (documentation only)
- [ ] Refactor (code restructuring)
- [ ] Test (test additions or changes)
- [ ] Performance (performance improvements)

## Changes

- Added runtime VS Code theme color resolution for Ant Design tokens.
- Updated webview theme mapping to use concrete colors instead of CSS variable strings.
- Preserved VS Code semantic CSS variables for Less/CSS usage.
- Improved themed styles for Select focus, Tooltip, Badge/Ribbon, MethodTag, skeleton loading, drawers, modals, and generated-result views.
- Added Monaco theme switching support for VS Code light, dark, and high-contrast themes.

## Screenshot

<img width="2216" height="1512" alt="image" src="https://github.com/user-attachments/assets/ecef8e96-1d92-4026-b3ec-8ed6e0fb0781" />

## Testing

- `pnpm --filter tswagger-webview build`
- `pnpm run test-compile`
- `pnpm run lint`
- `pnpm exec tsc --noEmit -p webview/tsconfig.json` reports the existing `CheckboxValueType` TS2614 issue in `webview/src/pages/context.ts`.

### Checklist

- [x] Code follows project style guidelines
- [x] Changes have been tested locally
- [ ] Documentation has been updated (if applicable)
- [ ] Changeset has been added (for versioned changes)
- [x] No sensitive information included

### Related Issues

N/A
